### PR TITLE
Make content flow intuitive to default progression

### DIFF
--- a/generators/app/templates/src/pages/index.soy
+++ b/generators/app/templates/src/pages/index.soy
@@ -60,6 +60,55 @@ description: "Something nice and compelling about the project. Make it short and
 /**
  *
  */
+{template .features}
+	<div class="features">
+		<div class="container">
+			<div class="row">
+				<section class="feature col-md-4 col-md-offset-2">
+					<div class="feature-graphic">
+						<span class="icon-16-bullhorn"></span>
+					</div>
+					<h3 class="feature-title">Heading</h3>
+					<p class="feature-description">Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros praesent commodo.</p>
+				</section>
+				<section class="feature col-md-4">
+					<div class="feature-graphic">
+						<span class="icon-16-lock"></span>
+					</div>
+					<h3 class="feature-title">Heading</h3>
+					<p class="feature-description">Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros praesent commodo.</p>
+				</section>
+				<section class="feature col-md-4">
+					<div class="feature-graphic">
+						<span class="icon-16-calendar"></span>
+					</div>
+					<h3 class="feature-title">Heading</h3>
+					<p class="feature-description">Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros praesent commodo.</p>
+				</section>
+			</div>
+		</div>
+	</div>
+{/template}
+
+/**
+ *
+ */
+{template .how}
+	<article class="about">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-12 col-md-offset-2">
+					<h3 class="about-title">It's easier than you think</h3>
+					<p class="about-description">Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros praesent commodo ultricies vehicula ut.</p>
+				</div>
+			</div>
+		</div>
+	</article>
+{/template}
+
+/**
+ *
+ */
 {template .highlights}
 	<div class="highlights">
 		<div class="container">
@@ -90,55 +139,6 @@ description: "Something nice and compelling about the project. Make it short and
 					<img class="highlight-image" src="http://placehold.it/500x400/e7e8e8/64696d" alt="Placeholder">
 				</div>
 			</section>
-		</div>
-	</div>
-{/template}
-
-/**
- *
- */
-{template .how}
-	<article class="about">
-		<div class="container">
-			<div class="row">
-				<div class="col-md-12 col-md-offset-2">
-					<h3 class="about-title">It's easier than you think</h3>
-					<p class="about-description">Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros praesent commodo ultricies vehicula ut.</p>
-				</div>
-			</div>
-		</div>
-	</article>
-{/template}
-
-/**
- *
- */
-{template .features}
-	<div class="features">
-		<div class="container">
-			<div class="row">
-				<section class="feature col-md-4 col-md-offset-2">
-					<div class="feature-graphic">
-						<span class="icon-16-bullhorn"></span>
-					</div>
-					<h3 class="feature-title">Heading</h3>
-					<p class="feature-description">Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros praesent commodo.</p>
-				</section>
-				<section class="feature col-md-4">
-					<div class="feature-graphic">
-						<span class="icon-16-lock"></span>
-					</div>
-					<h3 class="feature-title">Heading</h3>
-					<p class="feature-description">Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros praesent commodo.</p>
-				</section>
-				<section class="feature col-md-4">
-					<div class="feature-graphic">
-						<span class="icon-16-calendar"></span>
-					</div>
-					<h3 class="feature-title">Heading</h3>
-					<p class="feature-description">Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Nullam id dolor id nibh ultricies vehicula ut id elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros praesent commodo.</p>
-				</section>
-			</div>
 		</div>
 	</div>
 {/template}


### PR DESCRIPTION
I thought it might be easier if the templates were organized accordingly to the default progression of the landing page.