### PR TITLE
Adds default configuration to ghPages

### DIFF
--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -12,7 +12,5 @@ electric.registerTasks({
 
 gulp.task('deploy', ['build'], () => {
 	return gulp.src('dist/**/*')
-		.pipe(ghPages({
-			branch: 'wedeploy'
-		}));
+		.pipe(ghPages());
 });


### PR DESCRIPTION
`gulp-gh-pages` already creates the default `gh-pages` branch. By doing this, developers don't need to make any additional setup.