### PR TITLE
Import and initialize ElectricCodeTabs

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -3,6 +3,7 @@
   "name": "<%= projectId %>",
   "version": "0.0.0",
   "devDependencies": {
+    "electric-code-tabs": "^1.0.0-alpha.3",
     "electric-marble-components": "alpha",
     "marble": "~2.7.0",
     "metal-toggler": "^2.0.0"

--- a/generators/app/templates/src/components/ElectricCodeTabs
+++ b/generators/app/templates/src/components/ElectricCodeTabs
@@ -1,0 +1,5 @@
+import 'electric-code-tabs';
+
+document.addEventListener('DOMContentLoaded', function() {
+  new metal.ElectricCodeTabs();
+});


### PR DESCRIPTION
@zenorocha. This is another way to use the component. This one seems much better than my previous pull request and we can discard this https://github.com/electricjs/electric/pull/39 too.

By doing this way we also let users remove the `electric-code-tabs` easily.

cc. @Robert-Frampton, @brunobasto